### PR TITLE
Update Page for 2024 Edition

### DIFF
--- a/workshop.markdown
+++ b/workshop.markdown
@@ -3,6 +3,8 @@ layout: default
 title: HumanCLAIM Workshop
 description: The Human Perspective on Cross-Lingual AI Models
 ---
+The 2023 edition can be found [here](/workshop2023.markdown).
+
 ## Motivation
 
 Linguistic diversity is one of the fundamental rights of the European Union and we are optimistic that cross-lingual AI models can play an important role in facilitating it. Cross-lingual models based on neural networks are trained on terabytes of data and have recently reached large performance gains. As the computationally expensive training of such models can only be afforded by large companies, the evaluation of cross-lingual models is driven by commercial incentives and focuses on the average quantitative performance across more than a hundred languages. The intricacies of application scenarios for low-resource languages or economically insignificant purposes are largely being overlooked and individual differences between users are underestimated. When we want to use cross-lingual models for human-centered scenarios such as cognitive modeling, language education, or for use cases in the digital humanities, we quickly encounter their limitations. 
@@ -10,54 +12,16 @@ Linguistic diversity is one of the fundamental rights of the European Union and 
 In this workshop, we want to bring together leading scholars from linguistics, cognitive science, and computer science to develop a more diverse and human-centered perspective on cross-lingual models.  We want to integrate typological theories about differences between language families, cognitive models of multilingual processing, and computational approaches towards increasing diversity in language technology.
 
 Participation in the workshop is free of charge but the number of participants is limited. 
-Please register using this [form](https://docs.google.com/forms/d/e/1FAIpQLSfIqmEaLj5VmLYZnHYuXBZrI0f-lKn_nSPOQTAYtz0507eS3w/viewform?usp=pp_url). 
-
+Registration will open soon.
 
 ## Program
 
-**Day 1**: March 29 (Wednesday), 2pm-6pm <br>
-Location: Room Truss, [Volkshotel](https://www.volkshotel.nl/en/directions/) <br>
-
-| 14.00 | Lisa Beinborn: Human-Centered Challenges for Cross-Lingual Language Models |
-| 14.45 | Piek Vossen: Cross-lingual Reference for Learning Languages with Robots |
-| 15.30 | Coffee break |
-| 16.00 | Antal v.d. Bosch: Implicit and Explicit Multilingual Computational Language Models |
-| 16.45 | Poster Session |
-
-<br>
-
-**Day 2**, March 30 (Thursday), 9 am-5pm <br>
+January 11th (Wednesday), 9.30 am - 17.30 pm <br>
 Location: Interactive workspace [3D@VU](https://www.youtube.com/watch?v=Z3E2f56mptw) <br>
-
-| 09.00 | Anne Lauscher: Fostering Cultural and Subcultural Inclusion in NLP |
-| 10.00 | Coffee break |
-| 10.30  | Lonneke van der Plas: Language Specificity and Low-Resource Languages |
-| 11.30 | Discussion:  Challenges for Applying Cross-Lingual Models to Human-Centered Use Cases <br> Panel: Anne Lauscher, Lonneke van der Plas, Andrew Caines |
-| 12.30 | Lunch break |
-| 14.00 | Yevgen Matusevych: Targeted Evaluation of Bilingual Models |
-| 15.00 | Coffee break |
-| 15.30 | Discussion: Human-Centered Aspects in the Evaluation of Cross-Lingual Models <br> Panel: Yevgen Matusevych, Stefan Frank, Rochelle Choenni  |
-
+Full program to be announced soon.
 <br>
-
-**Confirmed Posters:**
-- Rochelle Choenni: Data-Efficient Cross-Lingual Transfer with Language-Specific Subnetworks
-- Charlotte Pouw: Cross-Lingual Transfer of Cognitive Complexity
-- Ece Takmaz: Transformer Adapters for the Multi- and Cross-Lingual Prediction of Human Reading Behavior
-- Marcell Fekete: Gradual Language Model Adaptation Using Fine-Grained Typology
-- Yiyi Chen: Improving Cross-Lingual Models with Semantic Typology
-- Antonia Karamolegkou: Investigation of Transfer Languages for Parsing Latin
-- Ester Ploeger: Machine Translation between Languages with Varying Semantic Typology
-- Philipp Rust: Language Modeling with Pixels
-- Richard Diehl Martinez: Framing Multi-Lingual Language Modeling as a Meta-Learning Task
-- Gabriele Sarti: DivEMT: Neural Machine Translation Post Editing Effort Across Typologically Diverse Languages
-- Andrew Caines: Cross-Lingual Word Segmentation
-- Adrielli Lopes Rego: Towards a Cross-Lingual Computational Model of Reading
-- Mark Breuker: Educational NLP for Language Learning
-- Lisa Beinborn: Modeling Disagreement in Cross-Lingual Eye-Tracking Signals
-- Plus a few more TBA
 
 ## Contact
 
-The workshop is sponsored by an Early Career Partnership awarded to Lisa Beinborn by the [Royal Netherlands Academy of Arts and Sciences (KNAW)](https://www.knaw.nl/en). 
+The workshop is sponsored by the [Network Institute](https://networkinstitute.org/). 
 If you have questions about the program, you can send an e-mail to humanclaim@googlegroups.com. 

--- a/workshop.markdown
+++ b/workshop.markdown
@@ -21,7 +21,12 @@ Location: Interactive workspace [3D@VU](https://www.youtube.com/watch?v=Z3E2f56m
 Full program to be announced soon.
 <br>
 
-## Contact
+## Organization Committee
+Lisa Beinborn (Vrije Universiteit Amsterdam) <br>
+Richard Diehl Martinez (University of Cambridge) <br>
+Urja Khurana (Vrije Universiteit Amsterdam)
 
-The workshop is sponsored by the [Network Institute](https://networkinstitute.org/). 
+## Contact
+The workshop is sponsored by the [Network Institute](https://networkinstitute.org/). <br>
 If you have questions about the program, you can send an e-mail to humanclaim@googlegroups.com. 
+

--- a/workshop.markdown
+++ b/workshop.markdown
@@ -16,7 +16,7 @@ Registration will open soon.
 
 ## Program
 
-January 11th (Wednesday), 9.30 am - 17.30 pm <br>
+January 11th (Thursday), 9.30 am - 17.30 pm <br>
 Location: Interactive workspace [3D@VU](https://www.youtube.com/watch?v=Z3E2f56mptw) <br>
 Full program to be announced soon.
 <br>

--- a/workshop.markdown
+++ b/workshop.markdown
@@ -16,7 +16,7 @@ Registration will open soon.
 
 ## Program
 
-January 11th (Thursday), 9.30 am - 17.30 pm <br>
+**January 11th (Thursday), 2024**, 9.30 am - 17.30 pm <br>
 Location: Interactive workspace [3D@VU](https://www.youtube.com/watch?v=Z3E2f56mptw) <br>
 Full program to be announced soon.
 <br>

--- a/workshop2023.markdown
+++ b/workshop2023.markdown
@@ -1,0 +1,63 @@
+---
+layout: default
+title: HumanCLAIM Workshop
+description: The Human Perspective on Cross-Lingual AI Models
+---
+## Motivation
+
+Linguistic diversity is one of the fundamental rights of the European Union and we are optimistic that cross-lingual AI models can play an important role in facilitating it. Cross-lingual models based on neural networks are trained on terabytes of data and have recently reached large performance gains. As the computationally expensive training of such models can only be afforded by large companies, the evaluation of cross-lingual models is driven by commercial incentives and focuses on the average quantitative performance across more than a hundred languages. The intricacies of application scenarios for low-resource languages or economically insignificant purposes are largely being overlooked and individual differences between users are underestimated. When we want to use cross-lingual models for human-centered scenarios such as cognitive modeling, language education, or for use cases in the digital humanities, we quickly encounter their limitations. 
+
+In this workshop, we want to bring together leading scholars from linguistics, cognitive science, and computer science to develop a more diverse and human-centered perspective on cross-lingual models.  We want to integrate typological theories about differences between language families, cognitive models of multilingual processing, and computational approaches towards increasing diversity in language technology.
+
+Participation in the workshop is free of charge but the number of participants is limited. 
+Please register using this [form](https://docs.google.com/forms/d/e/1FAIpQLSfIqmEaLj5VmLYZnHYuXBZrI0f-lKn_nSPOQTAYtz0507eS3w/viewform?usp=pp_url). 
+
+
+## Program
+
+**Day 1**: March 29 (Wednesday), 2pm-6pm <br>
+Location: Room Truss, [Volkshotel](https://www.volkshotel.nl/en/directions/) <br>
+
+| 14.00 | Lisa Beinborn: Human-Centered Challenges for Cross-Lingual Language Models |
+| 14.45 | Piek Vossen: Cross-lingual Reference for Learning Languages with Robots |
+| 15.30 | Coffee break |
+| 16.00 | Antal v.d. Bosch: Implicit and Explicit Multilingual Computational Language Models |
+| 16.45 | Poster Session |
+
+<br>
+
+**Day 2**, March 30 (Thursday), 9 am-5pm <br>
+Location: Interactive workspace [3D@VU](https://www.youtube.com/watch?v=Z3E2f56mptw) <br>
+
+| 09.00 | Anne Lauscher: Fostering Cultural and Subcultural Inclusion in NLP |
+| 10.00 | Coffee break |
+| 10.30  | Lonneke van der Plas: Language Specificity and Low-Resource Languages |
+| 11.30 | Discussion:  Challenges for Applying Cross-Lingual Models to Human-Centered Use Cases <br> Panel: Anne Lauscher, Lonneke van der Plas, Andrew Caines |
+| 12.30 | Lunch break |
+| 14.00 | Yevgen Matusevych: Targeted Evaluation of Bilingual Models |
+| 15.00 | Coffee break |
+| 15.30 | Discussion: Human-Centered Aspects in the Evaluation of Cross-Lingual Models <br> Panel: Yevgen Matusevych, Stefan Frank, Rochelle Choenni  |
+
+<br>
+
+**Confirmed Posters:**
+- Rochelle Choenni: Data-Efficient Cross-Lingual Transfer with Language-Specific Subnetworks
+- Charlotte Pouw: Cross-Lingual Transfer of Cognitive Complexity
+- Ece Takmaz: Transformer Adapters for the Multi- and Cross-Lingual Prediction of Human Reading Behavior
+- Marcell Fekete: Gradual Language Model Adaptation Using Fine-Grained Typology
+- Yiyi Chen: Improving Cross-Lingual Models with Semantic Typology
+- Antonia Karamolegkou: Investigation of Transfer Languages for Parsing Latin
+- Ester Ploeger: Machine Translation between Languages with Varying Semantic Typology
+- Philipp Rust: Language Modeling with Pixels
+- Richard Diehl Martinez: Framing Multi-Lingual Language Modeling as a Meta-Learning Task
+- Gabriele Sarti: DivEMT: Neural Machine Translation Post Editing Effort Across Typologically Diverse Languages
+- Andrew Caines: Cross-Lingual Word Segmentation
+- Adrielli Lopes Rego: Towards a Cross-Lingual Computational Model of Reading
+- Mark Breuker: Educational NLP for Language Learning
+- Lisa Beinborn: Modeling Disagreement in Cross-Lingual Eye-Tracking Signals
+- Plus a few more TBA
+
+## Contact
+
+The workshop is sponsored by an Early Career Partnership awarded to Lisa Beinborn by the [Royal Netherlands Academy of Arts and Sciences (KNAW)](https://www.knaw.nl/en). 
+If you have questions about the program, you can send an e-mail to humanclaim@googlegroups.com. 


### PR DESCRIPTION
This PR brings two changes: 

1. The _workshop.markdown_ is updated with information about the 2024 edition. 
2. The information about the previous edition in 2023 has been moved to _workshop2023.markdown_